### PR TITLE
fix: renamed postgres port parameter in database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ default: &default
   username: <%= ENV['POSTGRES_USER'] %>
   password: <%= ENV['POSTGRES_PASSWORD'] %>
   host: <%= ENV['POSTGRES_HOST'] %>
-  port: <%= ENV['POSTGRE_PORT'] %>
+  port: <%= ENV['POSTGRES_PORT'] %>
 
 development:
   <<: *default


### PR DESCRIPTION
O que foi feito:
- [x] Corrigido descrição do parâmetro da porta do PostrgreSql no Database.yml de POSTGRE_PORT para POSTGRES_PORT

Closes #118 